### PR TITLE
4.11 – Implement Generic Tree and `#fold` for it

### DIFF
--- a/src/main/scala/chapter5/Tree.scala
+++ b/src/main/scala/chapter5/Tree.scala
@@ -1,0 +1,14 @@
+package chapter5
+
+// Starting with just a string tree
+sealed trait Tree {
+  def fold: String = {
+    this match {
+      case Leaf(value) => value
+      case Node(left, right) => left.fold + " " + right.fold
+    }
+  }
+}
+
+final case class Leaf(value: String) extends Tree
+final case class Node(left: Tree, right: Tree) extends Tree

--- a/src/main/scala/chapter5/Tree.scala
+++ b/src/main/scala/chapter5/Tree.scala
@@ -1,14 +1,14 @@
 package chapter5
 
 // Starting with just a string tree
-sealed trait Tree {
-  def fold: String = {
+sealed trait Tree[A] {
+  def fold[A](joiner: (A, A) => A): A = {
     this match {
       case Leaf(value) => value
-      case Node(left, right) => left.fold + " " + right.fold
+      case Node(left, right) => joiner(left.fold(joiner), right.fold(joiner))
     }
   }
 }
 
-final case class Leaf(value: String) extends Tree
-final case class Node(left: Tree, right: Tree) extends Tree
+final case class Leaf[A](value: A) extends Tree[A]
+final case class Node[A](left: Tree[A], right: Tree[A]) extends Tree[A]

--- a/src/main/scala/chapter5/Tree.scala
+++ b/src/main/scala/chapter5/Tree.scala
@@ -1,11 +1,10 @@
 package chapter5
 
-// Starting with just a string tree
 sealed trait Tree[A] {
-  def fold[A](joiner: (A, A) => A): A = {
+  def fold[B](leaf: A => B, node: (B, B) => B): B = {
     this match {
-      case Leaf(value) => value
-      case Node(left, right) => joiner(left.fold(joiner), right.fold(joiner))
+      case Leaf(value) => leaf(value)
+      case Node(left, right) => node(left.fold(leaf, node), right.fold(leaf, node))
     }
   }
 }

--- a/src/test/scala/chapter5/TreeSpec.scala
+++ b/src/test/scala/chapter5/TreeSpec.scala
@@ -4,7 +4,7 @@ import org.dleve123.essentialscala.UnitSpec
 
 class TreeSpec extends UnitSpec {
   describe("#fold") {
-    it("returns a string representation of a Tree") {
+    it("returns a string representation of a complicated Tree") {
       val tree: Tree[String] =
         Node(
           Node(
@@ -24,7 +24,38 @@ class TreeSpec extends UnitSpec {
           )
         )
 
-      assert(tree.fold((left: String, right: String) => left + " " + right) == "To iterate is human, to recurse divine")
+      val foldResult = tree.fold[String](leaf => leaf, (left, right) => left + " " + right)
+      assert(foldResult == "To iterate is human, to recurse divine")
+    }
+
+    it("returns just the leaf (without padding) when the tree is just a leaf") {
+      val tree: Tree[String] = Leaf("hi")
+
+      assert(tree.fold[String](leaf => leaf, (left, right) => left + " " + right) == "hi")
+    }
+
+    it("proof of concept - can elegantly calculate the number of characters across all nodes") {
+      val tree: Tree[String] =
+        Node(
+          Node(
+            Leaf("a"), Leaf("bb")
+          ),
+          Node(
+            Node(
+              Leaf("ccc"), Leaf("dddd")
+            ),
+            Node(
+              Leaf("eeeee"),
+              Node(
+                Leaf("ffffff"),
+                Leaf("ggggggg")
+              )
+            )
+          )
+        )
+
+      val foldResult = tree.fold[Int](leaf => leaf.size, (left, right) => left + right)
+      assert(foldResult == 28)
     }
   }
 }

--- a/src/test/scala/chapter5/TreeSpec.scala
+++ b/src/test/scala/chapter5/TreeSpec.scala
@@ -1,0 +1,30 @@
+package chapter5
+
+import org.dleve123.essentialscala.UnitSpec
+
+class TreeSpec extends UnitSpec {
+  describe("#fold") {
+    it("returns a string representation of a Tree") {
+      val tree: Tree =
+        Node(
+          Node(
+            Leaf("To"), Leaf("iterate")
+          ),
+          Node(
+            Node(
+             Leaf("is"), Leaf("human,")
+            ),
+            Node(
+              Leaf("to"),
+              Node(
+                Leaf("recurse"),
+                Leaf("divine")
+              )
+            )
+          )
+        )
+
+      assert(tree.fold == "To iterate is human, to recurse divine")
+    }
+  }
+}

--- a/src/test/scala/chapter5/TreeSpec.scala
+++ b/src/test/scala/chapter5/TreeSpec.scala
@@ -5,7 +5,7 @@ import org.dleve123.essentialscala.UnitSpec
 class TreeSpec extends UnitSpec {
   describe("#fold") {
     it("returns a string representation of a Tree") {
-      val tree: Tree =
+      val tree: Tree[String] =
         Node(
           Node(
             Leaf("To"), Leaf("iterate")
@@ -24,7 +24,7 @@ class TreeSpec extends UnitSpec {
           )
         )
 
-      assert(tree.fold == "To iterate is human, to recurse divine")
+      assert(tree.fold((left: String, right: String) => left + " " + right) == "To iterate is human, to recurse divine")
     }
   }
 }


### PR DESCRIPTION
<img width="965" alt="Screen Shot 2019-06-17 at 6 32 09 PM" src="https://user-images.githubusercontent.com/1561546/59641099-498cd400-912e-11e9-9062-07b1b830e740.png">

Notably the essential scala solutions use Polymorphism instead of pattern matching (define `fold` on `Leaf` and `Node`), but I find the pattern matching approach a bit succincter and perhaps more direct..